### PR TITLE
Pod coverage testing is running under the AUTHOR_TESTING mode only

### DIFF
--- a/t/02pod-coverage.t
+++ b/t/02pod-coverage.t
@@ -1,6 +1,7 @@
 #!perl -T
 
 use Test::More;
+plan skip_all => "Pod coverage testing is running under the AUTHOR_TESTING mode only." unless $ENV{AUTHOR_TESTING};
 eval "use Test::Pod::Coverage 1.04";
 plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage" if $@;
 my $params = {


### PR DESCRIPTION
Skip pod coverage test if AUTHOR_TESTING is not true. 
Pod coverage test is not needed for install or use modules.

And 02pod-coverage.t fails if perl was compiled without threads support.
