### PR TITLE
don't send Transfer-Encoding chunked as response to CONNECT request

### DIFF
--- a/lib/HTTP/Proxy.pm
+++ b/lib/HTTP/Proxy.pm
@@ -526,8 +526,9 @@ sub _send_response_headers {
             $response->remove_header("Content-Length");
             $response->content('');
         }
-        elsif ( $response->request && $response->request->method eq "HEAD" )
+        elsif ( !$response->request || $response->request->method eq "HEAD" )
         {    # probably OK, says HTTP::Daemon
+	     # or Response w/o Request, i.e. CONNECT
         }
         else {
             if ( $conn->proto_ge("HTTP/1.1") ) {


### PR DESCRIPTION
If the client makes a `CONNECT` request with `HTTP/1.1` HTTP::Proxy will send a response with `Transfer-Encoding: chunked` back  and thus declaring that some HTTP body exists even if no HTTP body can exist for `CONNECT`. At least curl and Mojo::UserAgent cannot deal with this wrong response.

The commit changes the behavior so that it will on `CONNECT` like in will on `HEAD`, i.e. don't claim that a response body exists.

See also https://stackoverflow.com/questions/52723199/how-can-i-make-httpproxy-work-with-https-urls